### PR TITLE
Tagit ja kuvaus TipFormiin

### DIFF
--- a/frontend/public/styles.css
+++ b/frontend/public/styles.css
@@ -73,7 +73,7 @@ footer p {
   outline: none;
 }
 
-form.create-tip {
+.tipform {
   position: relative;
   width: 480px;
   margin: 30px auto 20px auto;
@@ -83,7 +83,7 @@ form.create-tip {
   box-shadow: 0 1px 5px rgb(138, 137, 137);
 }
 
-form.create-tip button {
+.tipform .formbutton {
   position: absolute;
   right: 18px;
   bottom: -18px;

--- a/frontend/src/components/Tags.js
+++ b/frontend/src/components/Tags.js
@@ -27,7 +27,7 @@ const Tags = props => {
       {props.editable && (
         <FormControl>
           <TextField
-            label="Add tags"
+            label="Tags"
             placeholder="Add a tag and click +"
             value={newTag}
             name="newtag"

--- a/frontend/src/components/Tags.test.js
+++ b/frontend/src/components/Tags.test.js
@@ -9,13 +9,13 @@ describe("<Tag> component rendering", () => {
   test("Rendering in read mode", () => {
     const component = render(<Tags tags={tags} />)
     expect(component.container).toHaveTextContent("tag1")
-    expect(component.container).not.toHaveTextContent("Add")
+    expect(component.container).not.toHaveTextContent("Tags")
   })
 
   test("Rendering in edit mode", () => {
     const component = render(<Tags tags={tags} editable={true} />)
     expect(component.container).toHaveTextContent("tag1")
-    expect(component.container).toHaveTextContent("Add")
+    expect(component.container).toHaveTextContent("Tags")
   })
 })
 

--- a/frontend/src/components/TipForm.js
+++ b/frontend/src/components/TipForm.js
@@ -1,19 +1,23 @@
 import React, { useState } from "react";
+
 import TextField from '@material-ui/core/TextField';
 import AddIcon from "@material-ui/icons/Add";
 import Fab from "@material-ui/core/Fab";
+
+import Tags from "./Tags"
 
 const TipForm = (props) => {
   const [isExpanded, setExpanded] = useState(false);
 
   const [tip, setTip] = useState({
     title: "",
-    link: ""
+    link: "",
+    description: "",
+    tags: []
   });
 
   const handleChange = (event) => {
     const { name, value } = event.target;
-
     setTip(prevTip => {
       return {
         ...prevTip,
@@ -22,11 +26,31 @@ const TipForm = (props) => {
     });
   }
 
+  const addTags = input => {
+    const newTags = tip.tags.concat(input.split(","))
+    const editedTip = {
+      ...tip,
+      tags: newTags
+    }
+    setTip(editedTip)
+  }
+
+  const deleteTag = tag => {
+    const editedTags = tip.tags.filter(t => t !== tag)
+    const editedTip = {
+      ...tip,
+      tags: editedTags
+    }
+    setTip(editedTip)
+  }
+
   const submitTip = (event) => {
     props.onAdd(tip);
     setTip({
       title: "",
-      link: ""
+      link: "",
+      description: "",
+      tags: []
     });
     event.preventDefault();
     setExpanded(false);
@@ -38,35 +62,58 @@ const TipForm = (props) => {
 
   return (
     <div>
-      <form className="create-tip">
+      <form className="tipform">
         <h3>Add a new tip</h3>
 
         <TextField
           name="title"
-          variant="outlined"
           label="Title"
+          variant="outlined"
           margin="normal"
           fullWidth={true}
+          value={tip.title}
           onChange={handleChange}
           onSelect={expand}
           onClick={expand}
-          value={tip.title}
         />
 
         {isExpanded &&
           <TextField
             name="link"
-            variant="outlined"
             label="Link"
+            variant="outlined"
             margin="normal"
             fullWidth={true}
-            onChange={handleChange}
             value={tip.link}
+            onChange={handleChange}
           />
         }
 
         {isExpanded &&
-          <Fab name="create" onClick={submitTip}>
+          <TextField
+            name="description"
+            label="Description"
+            variant="outlined"
+            margin="normal"
+            fullWidth={true}  
+            multiline
+            value={tip.description}
+            onChange={handleChange}
+          />
+        }
+
+        {isExpanded &&
+          <Tags
+            name="tags"
+            tags={tip.tags}
+            onAdd={addTags}
+            onDelete={deleteTag}
+            editable={true}
+          />
+        }
+
+        {isExpanded &&
+          <Fab name="create" className="formbutton" onClick={submitTip}>
             <AddIcon />
           </Fab>
         }

--- a/frontend/src/components/TipForm.test.js
+++ b/frontend/src/components/TipForm.test.js
@@ -17,6 +17,17 @@ describe("Not-expanded <TipForm> component", () => {
     expect(linkField).toBeNull()
   })
 
+  test("Component does not render description field", () => {
+    const component = render(<TipForm />)
+    const descriptionField = component.container.querySelector("[name='description'")
+    expect(descriptionField).toBeNull()
+  })
+
+  test("Component does not render tag component", () => {
+    const component = render(<TipForm />)
+    expect(component.container).not.toHaveTextContent("tag3")
+  })
+
   test("Component does not render create button", () => {
     const component = render(<TipForm />)
     const createBtn = component.container.querySelector("[name='create'")
@@ -42,6 +53,22 @@ describe("Expanded <TipForm> component", () => {
     expect(linkField).toBeInTheDocument()
   })
 
+  test("Component renders description input field", () => {
+    const component = render(<TipForm />)
+    const titleField = component.container.querySelector("[name='title'")
+    titleField.click()
+    const descriptionField = component.container.querySelector("[name='description'")
+    expect(descriptionField).toBeInTheDocument()
+  })
+
+  test("Component renders tag component", () => {
+    const component = render(<TipForm />)
+    const titleField = component.container.querySelector("[name='title'")
+    titleField.click()
+    expect(component.container).toHaveTextContent("Tags")
+  })
+
+
   test("Component renders create button", () => {
     const component = render(<TipForm />)
     const titleField = component.container.querySelector("[name='title'")
@@ -51,13 +78,16 @@ describe("Expanded <TipForm> component", () => {
   })
 })
 
-describe("<TipForm> submission", () => {
-  test("Form submits tip", () => {
-    const newTip = {
-      title: "New title",
-      link: "New link"
-    }
+describe("<TipForm> input", () => {
 
+  const newTip = {
+    title: "New title",
+    link: "New link",
+    description: "New description",
+    tags: ["omg"]
+  }
+
+  test("Form submits tip", () => {
     const addMock = jest.fn()
     const component = render(<TipForm onAdd={addMock} />)
     const titleField = component.container.querySelector("[name='title'")
@@ -65,9 +95,30 @@ describe("<TipForm> submission", () => {
     fireEvent.change(titleField, { target: { value: newTip.title } })
     const linkField = component.container.querySelector("[name='link'")
     fireEvent.change(linkField, { target: { value: newTip.link } })
+    const descriptionField = component.container.querySelector("[name='description'")
+    fireEvent.change(descriptionField, { target: { value: newTip.description } })
+    const newtag = component.container.querySelector("[name=newtag]")
+    fireEvent.change(newtag, { target: { value: newTip.tags[0] } })
+    const addtag = component.container.querySelector("[name=addtag]")
+    fireEvent.click(addtag)
     const createBtn = component.container.querySelector("[name='create'")
     fireEvent.click(createBtn)
     expect(addMock.mock.calls.length).toBe(1)
     expect(addMock.mock.calls[0][0]).toStrictEqual(newTip)
+  })
+
+  test("Tag can be deleted", () => {
+    const component = render(<TipForm />)
+    const titleField = component.container.querySelector("[name='title'")
+    titleField.click()
+    const newtag = component.container.querySelector("[name=newtag]")
+    fireEvent.change(newtag, { target: { value: newTip.tags[0] } })
+    const addtag = component.container.querySelector("[name=addtag]")
+    fireEvent.click(addtag)
+    const oldtag = component.container.querySelector(
+    `#deletetag-${newTip.tags[0]} .MuiSvgIcon-root`
+    )
+    fireEvent.click(oldtag)
+    expect(component.container).not.toHaveTextContent("tag2")
   })
 })

--- a/frontend/src/services/tips.js
+++ b/frontend/src/services/tips.js
@@ -8,6 +8,7 @@ const getAll = () => {
 }
 
 const create = newTip => {
+    console.log(newTip)
     const request = axios.post(apiUrl, newTip)
     return request.then(response => response.data)
 }

--- a/frontend/src/services/tips.js
+++ b/frontend/src/services/tips.js
@@ -8,7 +8,6 @@ const getAll = () => {
 }
 
 const create = newTip => {
-    console.log(newTip)
     const request = axios.post(apiUrl, newTip)
     return request.then(response => response.data)
 }


### PR DESCRIPTION
Lomakkeessa nyt kenttä kuvaukselle ja Tags-komponentti.  

Useamman tagin voi syöttää kerralla erottelemalla ne pilkuilla (addTagsissa on split(",")).

Tagikomponenttiin liittyy tyyliongelma minkä ratkomiseen ei jäänyt tänään aikaa: komponentin TextFieldillä on oma käsityksensä leveydestä joten fullWidth ei toimi odotetusti. Marginaalit kenttien välillä ovat myös tämän johdosta eri kokoiset. Kuvassa on aika monta nuolta mutta toivottavasti aukenee:

![1](https://user-images.githubusercontent.com/40494216/77462888-67017380-6e0d-11ea-9fcd-86f831187c1c.png)

Muutin myös Tipsin TextFieldin otsikoksi "Tags" yhdenmukaisuuden vuoksi.



